### PR TITLE
Exposes statsd format and send functions

### DIFF
--- a/statsd-client/statsd_client_core.ml
+++ b/statsd-client/statsd_client_core.ml
@@ -17,6 +17,19 @@ module Config : C = struct
   let log_error = ref (fun s -> Printf.eprintf "[error] %s\n%!" s)
 end
 
+let fmt_guage = Printf.sprintf "%d|g"
+let fmt_time = Printf.sprintf "%d|ms"
+let fmt_counting = Printf.sprintf "%d|c"
+let sec_to_ms time = int_of_float (time *. 1000.)
+let fmt_sample_rate sample_rate =
+  if sample_rate >= 1.0 then
+    ""  (* not sampling *)
+  else
+    Printf.sprintf "|@%f" sample_rate
+
+let fmt_statsd_payload ~sample_rate (metric_name, value_type) =
+  Printf.sprintf "%s:%s%s" metric_name value_type (fmt_sample_rate sample_rate)
+
 module type IO = sig
   val ipaddr         : unit -> string option
     (** Get the host ip address.  Allows for dynamic setting *)
@@ -44,9 +57,8 @@ module type T = sig
   type file_descr
   val ( >>= ) : 'a _r -> ('a -> 'b _r) -> 'b _r
   val socket_ref : file_descr option ref
-  val send_with_ipaddr_and_port :
-    string -> int -> float -> (string * string) list -> unit _r
-  val send : ?sample_rate:float -> (string * string) list -> unit _r
+  val send_with_ipaddr_and_port : string -> int -> string list -> unit _r
+  val send : data:string list -> unit _r
   val gauge : ?sample_rate:float -> string -> int -> unit _r
   val timing : ?sample_rate:float -> string -> int -> unit _r
   val timingf : ?sample_rate:float -> string -> float -> unit _r
@@ -64,83 +76,77 @@ module Make (U : IO) :
   let socket_ref = ref None
 
   (** Send the the stats over UDP *)
-  let send_with_ipaddr_and_port ipaddr port sample_rate data =
-    if sample_rate >= 1.0 || sample_rate >= Random.float 1.0 then
-      U.catch (fun () ->
+  let send_with_ipaddr_and_port ipaddr port data =
+    U.catch (fun () ->
         (* getprotobyname call hangs on Mac OS X 10.8.3 -->> Removed  *)
         (* U.getprotobyname "udp" >>= fun protocol_entry ->
-        let proto = protocol_entry.Unix.p_proto in
+           let proto = protocol_entry.Unix.p_proto in
         *)
         let proto = 17 (* UDP *) in
         (* Get or make the socket *)
         let socket =
           match !socket_ref with
-            | Some s -> s
-            | None   ->
-              !Config.log_debug "Creating statsd socket";
-              let s = U.socket Unix.PF_INET Unix.SOCK_DGRAM proto in
-              socket_ref := Some s;
-              s
+          | Some s -> s
+          | None   ->
+            !Config.log_debug "Creating statsd socket";
+            let s = U.socket Unix.PF_INET Unix.SOCK_DGRAM proto in
+            socket_ref := Some s;
+            s
         in
         let portaddr = Unix.ADDR_INET (Unix.inet_addr_of_string ipaddr, port) in
-        (* Map sample_rate to the string statsd expects *)
-        let sample_rate =
-          if sample_rate >= 1.0 then
-            ""  (* not sampling *)
-          else
-            Printf.sprintf "|@%f" sample_rate
-        in
         U.list_iter
-          (fun (stat, value) ->
-            let msg = Printf.sprintf "%s:%s%s" stat value sample_rate in
-            U.sendto socket msg 0 (String.length msg) [] portaddr
-            >>= (fun retval ->
-              if retval < 0 then
-                begin
-                  (* Ran into an error, clear the reference
-                     and close the socket *)
-                  socket_ref := None;
-                  U.catch
-                    (fun () ->
-                      !Config.log_debug
-                        (Printf.sprintf "Closing statsd socket: %d" retval);
-                      U.close socket >>= U.return)
-                    (fun _e -> U.return ());
-                end
-              else U.return ()
-            )
+          (fun msg ->
+             U.sendto socket msg 0 (String.length msg) [] portaddr
+             >>= (fun retval ->
+                 if retval < 0 then
+                   begin
+                     (* Ran into an error, clear the reference
+                        and close the socket *)
+                     socket_ref := None;
+                     U.catch
+                       (fun () ->
+                          !Config.log_debug
+                            (Printf.sprintf "Closing statsd socket: %d" retval);
+                          U.close socket >>= U.return)
+                       (fun _e -> U.return ());
+                   end
+                 else U.return ()
+               )
           )
           data
-      ) (fun _e -> U.return ()
-      )
-    else U.return ()
+      ) (fun _e -> U.return ())
 
-  let send ?(sample_rate = 1.0) data =
+  let send ~data =
     match U.ipaddr (), U.port () with
-      | None, _ | _, None ->
-        !Config.log_error
-          "Statsd_client.send: \
-           uninitialized Statsd_client.host or Statsd_client.port";
-        U.return ()
-      | Some ipaddr, Some port ->
-        send_with_ipaddr_and_port ipaddr port sample_rate data
+    | None, _ | _, None ->
+      !Config.log_error
+        "Statsd_client.send: \
+         uninitialized Statsd_client.host or Statsd_client.port";
+      U.return ()
+    | Some ipaddr, Some port ->
+      send_with_ipaddr_and_port ipaddr port data
+
+  let fmt_data ?(sample_rate = 1.0) data =
+    if sample_rate >= 1.0 || sample_rate >= Random.float 1.0
+    then List.map (fmt_statsd_payload ~sample_rate) data
+    else []
 
   let gauge ?sample_rate stat v =
-    send ?sample_rate [stat, Printf.sprintf "%d|g" v]
+    send (fmt_data ?sample_rate [stat, fmt_guage v])
 
   (** Log timing info. time is an int of milliseconds. *)
   let timing ?sample_rate stat time =
-    send ?sample_rate [stat, Printf.sprintf "%d|ms" time]
+    send (fmt_data ?sample_rate [stat, fmt_time time])
 
   (** Log timing info. time is a float of seconds which will
       be converted to milliseconds. *)
   let timingf ?sample_rate stat time =
-    timing ?sample_rate stat (int_of_float (time *. 1000.))
+    timing ?sample_rate stat (sec_to_ms time)
 
   (** Update a list of counter stats by some delta *)
   let update_stats ?sample_rate delta stats =
-    let delta = Printf.sprintf "%d|c" delta in
-    send ?sample_rate (List.map (fun stat -> stat, delta) stats)
+    let delta = fmt_counting delta in
+    send (fmt_data ?sample_rate (List.map (fun stat -> stat, delta) stats))
 
   (** Increment a list of counter stats by one *)
   let increment ?sample_rate stats =

--- a/statsd-client/statsd_client_core.mli
+++ b/statsd-client/statsd_client_core.mli
@@ -11,6 +11,32 @@ end
 
 module Config : C
 
+(** Formats guage metric type *)
+val fmt_guage : int -> string
+
+(** Formats time metric type *)
+val fmt_time : int -> string
+
+(** Formats counting metric type *)
+val fmt_counting : int -> string
+
+(** Map sample_rate to the string statsd expects *)
+val fmt_sample_rate : float -> string
+
+(** Formats statsd payload according to statsd:
+    ```
+    <metricname>:<value>|<type>|@<sample rate>
+    ```
+    For more details see: https://github.com/etsy/statsd *)
+val fmt_statsd_payload
+  : sample_rate:float
+  -> (string * string)
+  (** Tuple is expected to be of the form (<metric_name>, <value>|<type>) *)
+  -> string
+
+(** converts a float of seconds to an int of milliseconds *)
+val sec_to_ms : float -> int
+
 module type IO = sig
   val ipaddr         : unit -> string option
     (** Get the host ip address.  Allows for dynamic setting *)
@@ -38,9 +64,8 @@ module type T = sig
   type file_descr
   val ( >>= ) : 'a _r -> ('a -> 'b _r) -> 'b _r
   val socket_ref : file_descr option ref
-  val send_with_ipaddr_and_port :
-    string -> int -> float -> (string * string) list -> unit _r
-  val send : ?sample_rate:float -> (string * string) list -> unit _r
+  val send_with_ipaddr_and_port : string -> int -> string list -> unit _r
+  val send : data:string list -> unit _r
   val gauge : ?sample_rate:float -> string -> int -> unit _r
   val timing : ?sample_rate:float -> string -> int -> unit _r
   (** Log timing info. time is an int of milliseconds. *)


### PR DESCRIPTION
Motivation for this commit is to give the user access to statsd message
formatting functions and a low level send function in order allow the
user to extend the statsd protocol. Based on top of #5 