### PR TITLE
convert string to bytes - 4.06

### DIFF
--- a/statsd-client-lwt/statsd_client_lwt.ml
+++ b/statsd-client-lwt/statsd_client_lwt.ml
@@ -10,6 +10,9 @@ module T = struct
   let list_iter = Lwt_list.iter_p
 
   include Lwt_unix
+  let sendto fd msg offset msg_length flags socket_address =
+    let msg = Bytes.of_string msg in
+    Lwt_unix.sendto fd msg offset msg_length flags socket_address
   let socket dom typ proto = Lwt_unix.socket dom typ proto
 end
 

--- a/statsd-client/statsd_client_sync.ml
+++ b/statsd-client/statsd_client_sync.ml
@@ -11,6 +11,7 @@ include Statsd_client_core.Make (
     let list_iter f lst = List.iter f lst
 
     include Unix
+    let sendto = sendto_substring
     let socket dom typ proto = Unix.socket dom typ proto
   end
 )


### PR DESCRIPTION
Previously, we were relying on strings + bytes being interchangeable.
From 4.06 onwards, they will not be: https://ocaml.org/releases/4.06.html

This converts strings to bytes where appropriate (or uses the string fn if available)